### PR TITLE
fix: php can not load file via simplexml and curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update && apt-get install -y \
   php-cli \
   php-mysql \
   mariadb-client \
-  lftp
+  lftp \
+  php-simplexml \
+  php-curl
 
 RUN gem install wordmove --version 5.0.2
 RUN curl -o /usr/local/bin/wp -L https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \


### PR DESCRIPTION
I have fixed a issue when use `wordmove pull -e staging --all` for some plugins: Digits and WPML